### PR TITLE
Adding DockerMonitor project

### DIFF
--- a/DockerMonitor/README.md
+++ b/DockerMonitor/README.md
@@ -1,0 +1,11 @@
+# Docker Monitor
+
+Simple Vantiq Client Builder application that can monitor docker containers resource utilization for the local host system. The utilization data is provided by the docker API. 
+
+* [Full instructions](https://github.com/pburma/vantiqexamples/tree/master/docker_examples/system_monitor)
+
+*Screenshot*
+![image(https://user-images.githubusercontent.com/11183903/156450749-089cd78a-2b88-4f7d-9ead-2db2c0e28246.png)
+
+Once the docker API is active and accessible this project will load usage data from each container. This information can be used to create custom alerts and monitor system health. For example to send a low disk space alert or high CPU utilization notification.
+

--- a/DockerMonitor/README.md
+++ b/DockerMonitor/README.md
@@ -5,7 +5,7 @@ Simple Vantiq Client Builder application that can monitor docker containers reso
 * [Full instructions](https://github.com/pburma/vantiqexamples/tree/master/docker_examples/system_monitor)
 
 *Screenshot*
-![image(https://user-images.githubusercontent.com/11183903/156450749-089cd78a-2b88-4f7d-9ead-2db2c0e28246.png)
+![image](https://user-images.githubusercontent.com/11183903/156450749-089cd78a-2b88-4f7d-9ead-2db2c0e28246.png)
 
 Once the docker API is active and accessible this project will load usage data from each container. This information can be used to create custom alerts and monitor system health. For example to send a low disk space alert or high CPU utilization notification.
 

--- a/DockerMonitor/clients/DockerMonitor.json
+++ b/DockerMonitor/clients/DockerMonitor.json
@@ -1,0 +1,103 @@
+{
+  "ars_properties" : {
+    "tags" : [ "#launchable" ]
+  },
+  "ars_public" : false,
+  "ars_relationships" : [ ],
+  "controllers" : {
+    "client" : { },
+    "dataStream" : {
+      "ce_listContainers" : { }
+    },
+    "page" : {
+      "Start" : {
+        "onStart" : "RELOCATED to controllers/page/Start/onStart.js"
+      }
+    }
+  },
+  "isComponent" : false,
+  "isLaunchable" : true,
+  "models" : {
+    "dataObjects" : {
+      "__GLOBAL__" : {
+        "properties" : { }
+      },
+      "__PARAMETERS__" : {
+        "properties" : { }
+      }
+    },
+    "dataStreams" : [ {
+      "advancedWhereClause" : null,
+      "dataObjectName" : null,
+      "dataTypeList" : [ {
+        "label" : null,
+        "type" : "listContainers"
+      } ],
+      "isDeleteOp" : false,
+      "isInsertOp" : false,
+      "isUpdateOp" : false,
+      "maxRecords" : 0,
+      "name" : "ce_listContainers",
+      "pauseAtStartup" : false,
+      "property" : null,
+      "sortByProperty" : null,
+      "sortDescending" : false,
+      "type" : 5,
+      "updateInterval" : 60,
+      "uuid" : "ae09760c-5951-4b37-af1f-eac640873b90",
+      "v" : 1
+    } ]
+  },
+  "name" : "DockerMonitor",
+  "options" : {
+    "RELOCATE" : [ {
+      "path" : "controllers",
+      "type" : "js"
+    }, {
+      "path" : "views",
+      "type" : "json"
+    } ],
+    "activeTab" : "edit",
+    "badgeCount" : 0,
+    "componentConfiguration" : {
+      "configurationProperties" : [ ]
+    },
+    "description" : "",
+    "docAssets" : [ "Docker.js" ],
+    "jsAssets" : [ "../../docs/Docker.js" ],
+    "productV" : "7.7i",
+    "showCategoryButtons" : true,
+    "showCategoryDataDisplay" : true,
+    "showCategoryDataInput" : true,
+    "showCategoryLayout" : true,
+    "showGridWhileEditing" : false,
+    "theme" : {
+      "backgroundColor" : "#ffffff",
+      "borderColor" : "#8b572a",
+      "cardAccentColor" : "#8b572a",
+      "cardColor" : "#fee3b7",
+      "dataDisplayColor" : "#ffffff",
+      "dataDisplayColors" : [ "#3cbce1", "#996db8", "#86d557", "#ff9800", "#425b71", "#cc467c", "#01aa93", "#ffca28", "#f583a9", "#1c84d4", "#ff6767", "#4caf50" ],
+      "dataInputColor" : "#ffffff",
+      "foregroundColor" : "#8b572a",
+      "label" : "Custom",
+      "name" : "custom",
+      "titleBarColor" : "#fee3b7",
+      "titleForegroundColor" : "#1f1d17",
+      "v" : 3
+    },
+    "v" : 5
+  },
+  "resourceBinding" : {
+    "requiredResources" : [ {
+      "resource" : "topics",
+      "resourceId" : "/my/response/topic",
+      "type" : "publishes"
+    } ]
+  },
+  "targetDevice" : "all",
+  "userList" : [ ],
+  "views" : {
+    "Start" : "RELOCATED to views/Start.json"
+  }
+}

--- a/DockerMonitor/clients/DockerMonitor/controllers/page/Start/onStart.js
+++ b/DockerMonitor/clients/DockerMonitor/controllers/page/Start/onStart.js
@@ -1,0 +1,3 @@
+    Docker.listContainers(function(results){
+    	client.sendClientEvent("ce_listContainers", results);
+	});

--- a/DockerMonitor/clients/DockerMonitor/views/Start.json
+++ b/DockerMonitor/clients/DockerMonitor/views/Start.json
@@ -1,0 +1,88 @@
+{
+  "bodyChildren" : {
+    "rootArray" : [ "bc83e18c-8f85-4558-8eb1-2d9ad9c57b65" ],
+    "widgets" : [ {
+      "backgroundColor" : "default",
+      "borderColor" : "Default",
+      "borderRadius" : 4,
+      "borderThickness" : 1,
+      "cellFontColor" : "default",
+      "cellFontFace" : "inherit",
+      "cellFontSize" : 14,
+      "cellFontStyle" : "plain",
+      "clearOnDataArrive" : true,
+      "columnDescriptors" : [ {
+        "colorRules" : null,
+        "dataType" : "String",
+        "propertyName" : "containerName",
+        "selected" : false,
+        "title" : "Name"
+      }, {
+        "colorRules" : null,
+        "dataType" : "String",
+        "propertyName" : "cpuPercent",
+        "selected" : false,
+        "title" : "% CPU"
+      }, {
+        "colorRules" : null,
+        "dataType" : "String",
+        "propertyName" : "memPercent",
+        "selected" : false,
+        "title" : "% Memory"
+      }, {
+        "colorRules" : null,
+        "dataType" : "String",
+        "propertyName" : "DiskSize",
+        "selected" : false,
+        "title" : "DiskSize"
+      }, {
+        "colorRules" : null,
+        "dataType" : "String",
+        "propertyName" : "DiskUsed",
+        "selected" : false,
+        "title" : "DiskUsed"
+      }, {
+        "colorRules" : null,
+        "dataType" : "String",
+        "propertyName" : "DiskAvailable",
+        "selected" : false,
+        "title" : "DiskAvailable"
+      }, {
+        "colorRules" : null,
+        "dataType" : "String",
+        "propertyName" : "DiskUsage",
+        "selected" : false,
+        "title" : "DiskUsage"
+      } ],
+      "columnSort" : true,
+      "dataStreamGroupedByFiltersString" : "",
+      "dataStreamUUID" : "ae09760c-5951-4b37-af1f-eac640873b90",
+      "dataType" : null,
+      "headerFontColor" : "default",
+      "headerFontFace" : "inherit",
+      "headerFontSize" : 14,
+      "headerFontStyle" : "plain",
+      "heightPolicy" : "naturalSize",
+      "horzGravity" : "center",
+      "name" : "DataTable1",
+      "operation" : "insert",
+      "rowsPerPage" : 6,
+      "showPaging" : true,
+      "type" : "DataTable",
+      "uuid" : "bc83e18c-8f85-4558-8eb1-2d9ad9c57b65",
+      "v" : 17,
+      "vertGravity" : "center",
+      "w" : 942,
+      "widthPolicy" : "explicit",
+      "x" : 126,
+      "y" : 63.19999694824219
+    } ]
+  },
+  "data" : {
+    "properties" : { }
+  },
+  "footerChildren" : [ ],
+  "hasFooter" : false,
+  "layoutType" : "browser",
+  "responseTopic" : "/my/response/topic"
+}

--- a/DockerMonitor/documents/Docker.js
+++ b/DockerMonitor/documents/Docker.js
@@ -1,0 +1,177 @@
+// Generated on "2022-01-25T19:21:19.714Z"
+var Docker = {};
+
+Docker.getDiskUsage = function (containerId, successCallback, failureCallback) {
+    var procedureName = "Docker.getDiskUsage";
+    //
+    //  Create an instance of the Http class to execute our server request
+    //
+    var http = new Http();
+
+    //
+    //  Build the URL needed to do an "execute" of a Procedure
+    //
+    http.setVantiqUrlForSystemResource("procedures");
+
+    //
+    //  Add the Authorization header to the request
+    //
+    http.setVantiqHeaders();
+
+    //
+    //  Set the Procedure arguments by name. (You may also specify 'args' as an array where the
+    //  parameters are given in the same order as in the Procedure definition (e.g. 'args = [10,20];').
+    //  'args' must not be null.
+    //
+    var args = {containerId:containerId};
+
+    //
+    //  Execute the asynchronous server request. This expects 4 parameters:
+    //
+    //  procedureArguments: The procedure arguments.
+    //  procedureName:      The fully-qualified name of the Procedure.
+    //  successCallback:    A callback function that will be driven when the request completes
+    //                      successfully (i.e. a status code of 2XX)
+    //  failureCallback:    A callback function that will be driven when the request does not complete
+    //                      successfully.
+    //
+    http.execute(args, procedureName ,function(response)
+        {
+            //
+            //  At this point "response" is results of the Procedure call
+            //
+            if (successCallback) {
+                successCallback(response);
+            }
+        },
+        function(errors)
+        {
+            if (failureCallback) {
+                failureCallback(errors)
+            } else {
+                var errorMsg = "Procedure "+procedureName+" returned error: ";
+                if (errors.data && (errors.data.length>0)) {
+                    throw errorMsg+errors.data[0].message;
+                } else {
+                    throw errorMsg+JSON.stringify(errors);
+                }
+            }
+        });
+};
+
+Docker.listContainers = function (successCallback, failureCallback) {
+    var procedureName = "Docker.listContainers";
+    //
+    //  Create an instance of the Http class to execute our server request
+    //
+    var http = new Http();
+
+    //
+    //  Build the URL needed to do an "execute" of a Procedure
+    //
+    http.setVantiqUrlForSystemResource("procedures");
+
+    //
+    //  Add the Authorization header to the request
+    //
+    http.setVantiqHeaders();
+
+    //
+    //  Set the Procedure arguments by name. (You may also specify 'args' as an array where the
+    //  parameters are given in the same order as in the Procedure definition (e.g. 'args = [10,20];').
+    //  'args' must not be null.
+    //
+    var args = {};
+
+    //
+    //  Execute the asynchronous server request. This expects 4 parameters:
+    //
+    //  procedureArguments: The procedure arguments.
+    //  procedureName:      The fully-qualified name of the Procedure.
+    //  successCallback:    A callback function that will be driven when the request completes
+    //                      successfully (i.e. a status code of 2XX)
+    //  failureCallback:    A callback function that will be driven when the request does not complete
+    //                      successfully.
+    //
+    http.execute(args, procedureName ,function(response)
+        {
+            //
+            //  At this point "response" is results of the Procedure call
+            //
+            if (successCallback) {
+                successCallback(response);
+            }
+        },
+        function(errors)
+        {
+            if (failureCallback) {
+                failureCallback(errors)
+            } else {
+                var errorMsg = "Procedure "+procedureName+" returned error: ";
+                if (errors.data && (errors.data.length>0)) {
+                    throw errorMsg+errors.data[0].message;
+                } else {
+                    throw errorMsg+JSON.stringify(errors);
+                }
+            }
+        });
+};
+
+Docker.getStats = function (containerId, successCallback, failureCallback) {
+    var procedureName = "Docker.getStats";
+    //
+    //  Create an instance of the Http class to execute our server request
+    //
+    var http = new Http();
+
+    //
+    //  Build the URL needed to do an "execute" of a Procedure
+    //
+    http.setVantiqUrlForSystemResource("procedures");
+
+    //
+    //  Add the Authorization header to the request
+    //
+    http.setVantiqHeaders();
+
+    //
+    //  Set the Procedure arguments by name. (You may also specify 'args' as an array where the
+    //  parameters are given in the same order as in the Procedure definition (e.g. 'args = [10,20];').
+    //  'args' must not be null.
+    //
+    var args = {containerId:containerId};
+
+    //
+    //  Execute the asynchronous server request. This expects 4 parameters:
+    //
+    //  procedureArguments: The procedure arguments.
+    //  procedureName:      The fully-qualified name of the Procedure.
+    //  successCallback:    A callback function that will be driven when the request completes
+    //                      successfully (i.e. a status code of 2XX)
+    //  failureCallback:    A callback function that will be driven when the request does not complete
+    //                      successfully.
+    //
+    http.execute(args, procedureName ,function(response)
+        {
+            //
+            //  At this point "response" is results of the Procedure call
+            //
+            if (successCallback) {
+                successCallback(response);
+            }
+        },
+        function(errors)
+        {
+            if (failureCallback) {
+                failureCallback(errors)
+            } else {
+                var errorMsg = "Procedure "+procedureName+" returned error: ";
+                if (errors.data && (errors.data.length>0)) {
+                    throw errorMsg+errors.data[0].message;
+                } else {
+                    throw errorMsg+JSON.stringify(errors);
+                }
+            }
+        });
+};
+

--- a/DockerMonitor/procedures/Docker.getDiskUsage.vail
+++ b/DockerMonitor/procedures/Docker.getDiskUsage.vail
@@ -1,0 +1,98 @@
+PROCEDURE Docker.getDiskUsage(containerId String)
+
+var b1 = {
+    "AttachStdin": false,
+    "AttachStdout": true,
+    "AttachStderr": true,
+    "DetachKeys": "ctrl-p,ctrl-q",
+    "Tty": false,
+    "Cmd": 
+[
+    "/bin/bash", "-c", "df -h"
+],
+"Env": 
+    [
+    ]
+}
+
+var b2 = {
+
+    "Detach": false,
+    "Tty": true
+
+}
+
+SELECT ONE FROM SOURCE DockerAPI AS execId WITH path="v1.41/containers/" + containerId +  "/exec", method="POST", body=b1
+SELECT ONE FROM SOURCE DockerAPI AS data WITH path="v1.41/exec/" + execId.Id + "/start", method="POST", body=b2, responseType="text/*"
+var obj = {}
+
+if(data){
+	if(startsWith(data, "OCI")){
+		obj.size = "N/A"
+		obj.used = "N/A"
+		obj.available = "N/A"
+		obj.use = "N/A" 
+	}
+	else {
+        var pattern = regExp("overlay\D*(\d+\.\d+\D|\d+\D)\s+(\d+\.\d+\D|\d+\D)\s+(\d+\.\d+\D|\d+\D)\s+(\d+\.\d+\D|\d+\D)")
+		var matcher = pattern.matcher(data)
+		var i = 0 // you must do this and use intValue
+		var results =matcher[i.intValue()]
+		var obj = {}
+		obj.size = results[1]
+		obj.used = results[2]
+		obj.available = results[3]
+		obj.use = results[4]        
+	}
+}
+else {
+	obj.size = "N/A"
+	obj.used = "N/A"
+	obj.available = "N/A"
+	obj.use = "N/A" 
+}
+
+return obj
+
+/*
+var b1 = {
+    "AttachStdin": false,
+    "AttachStdout": true,
+    "AttachStderr": true,
+    "DetachKeys": "ctrl-p,ctrl-q",
+    "Tty": false,
+    "Cmd": 
+[
+    "/bin/bash", "-c", "df -H | grep overlay | awk '{printf \"%s\", $5}'"
+],
+"Env": 
+    [
+    ]
+}
+
+var b2 = {
+
+    "Detach": false,
+    "Tty": true
+
+}
+
+SELECT ONE FROM SOURCE DockerAPI AS execId WITH path="v1.41/containers/" + containerId +  "/exec", method="POST", body=b1
+SELECT ONE FROM SOURCE DockerAPI AS df WITH path="v1.41/exec/" + execId.Id + "/start", method="POST", body=b2, responseType="text/*"
+
+
+if(df){
+    if(endsWith(df, "%")){
+    	return df        
+	}
+	else {
+    return "N/A"    
+	}
+	
+}
+else {
+    return "N/A"
+}
+
+*/
+

--- a/DockerMonitor/procedures/Docker.getStats.vail
+++ b/DockerMonitor/procedures/Docker.getStats.vail
@@ -1,0 +1,27 @@
+PROCEDURE Docker.getStats(containerId String)
+
+//9393a8f1ff7d
+SELECT ONE FROM SOURCE DockerAPI AS stats WITH path="v1.41/containers/" + containerId + "/stats?stream=false"
+
+var obj = {}
+
+//Calculate CPU Stats
+var cpuPercent = 0.0
+var previousCPU = stats.precpu_stats.cpu_usage.total_usage
+var previousSystem = stats.precpu_stats.system_cpu_usage
+var cpuDelta = stats.cpu_stats.cpu_usage.total_usage - previousCPU
+var systemDelta = stats.cpu_stats.system_cpu_usage - previousSystem
+if(systemDelta > 0 AND cpuDelta > 0){
+    cpuPercent = ((cpuDelta/systemDelta) * length(stats.cpu_stats.cpu_usage.percpu_usage)) * 100
+}
+
+obj.cpuPercent = toDecimal(cpuPercent, 2)
+
+//Calculate memory stats
+obj.memPercent = toDecimal(((stats.memory_stats.usage / stats.memory_stats.limit) * 100), 2)
+
+return obj
+
+
+
+

--- a/DockerMonitor/procedures/Docker.listContainers.vail
+++ b/DockerMonitor/procedures/Docker.listContainers.vail
@@ -1,0 +1,24 @@
+/* Returns the system utilization stats from any running container. 
+*/
+PROCEDURE Docker.listContainers()
+
+SELECT ONE FROM SOURCE DockerAPI AS containers WITH path="v1.41/containers/json?all=false"
+
+var results = []
+
+FOR container IN containers {
+    var obj = {}
+    var stats = Docker.getStats(container.Id)
+	var disk = Docker.getDiskUsage(container.Id)
+    obj.containerId = container.Id
+    obj.containerName = replace(container.Names[0], "/", "")
+	obj.DiskUsage = disk.use
+	obj.DiskSize = disk.size
+	obj.DiskUsed = disk.used
+	obj.DiskAvailable = disk.available
+	obj.cpuPercent = toString(stats.cpuPercent) + "%"
+	obj.memPercent = toString(stats.memPercent) + "%"
+	push(results, obj)	
+}
+
+return results

--- a/DockerMonitor/projects/DockerMonitor.json
+++ b/DockerMonitor/projects/DockerMonitor.json
@@ -1,0 +1,163 @@
+{
+  "ars_relationships" : [ ],
+  "links" : [ {
+    "source" : "services/Docker",
+    "target" : "procedure/Docker.getDiskUsage"
+  }, {
+    "source" : "services/Docker",
+    "target" : "procedure/Docker.listContainers"
+  }, {
+    "source" : "services/Docker",
+    "target" : "procedure/Docker.getStats"
+  }, {
+    "source" : "procedure/Docker.listContainers",
+    "target" : "source/DockerAPI"
+  }, {
+    "source" : "procedure/Docker.listContainers",
+    "target" : "procedure/Docker.getStats"
+  }, {
+    "source" : "procedure/Docker.listContainers",
+    "target" : "procedure/Docker.getDiskUsage"
+  }, {
+    "source" : "procedure/Docker.listContainers",
+    "target" : "services/Docker"
+  }, {
+    "source" : "procedure/Docker.getStats",
+    "target" : "source/DockerAPI"
+  }, {
+    "source" : "procedure/Docker.getStats",
+    "target" : "services/Docker"
+  }, {
+    "source" : "procedure/Docker.getDiskUsage",
+    "target" : "source/DockerAPI"
+  }, {
+    "source" : "procedure/Docker.getDiskUsage",
+    "target" : "services/Docker"
+  }, {
+    "source" : "client/DockerMonitor",
+    "target" : "topic//my/response/topic"
+  } ],
+  "name" : "DockerMonitor",
+  "options" : {
+    "description" : "",
+    "dockCollapsed" : {
+      "bottom" : true,
+      "left" : false,
+      "right" : false,
+      "top" : false,
+      "viewtabs" : false
+    },
+    "dockDimensions" : {
+      "bottom" : 203,
+      "debug" : [ 503.55430528375734, 1029.4456947162425 ],
+      "left" : 210,
+      "right" : 220,
+      "top" : 0,
+      "viewtabs" : 0
+    },
+    "dockSort" : 1,
+    "filterBitArray" : "ffffffffffffffffffffffffffffffff",
+    "isModeloProject" : true,
+    "layoutStyle" : "tile",
+    "openFolders" : [ "services", "client", "type", "topic", "source" ],
+    "rootViewFlavor" : 1,
+    "showGrid" : true,
+    "tileColumns" : 2,
+    "tileRows" : 1,
+    "type" : "dev",
+    "v" : 4,
+    "viewUUID" : "MAINVIEW"
+  },
+  "resources" : [ {
+    "label" : "/my/response/topic",
+    "name" : "/my/response/topic",
+    "resourceReference" : "/topics//my/response/topic",
+    "type" : 10
+  }, {
+    "label" : "Docker",
+    "name" : "Docker",
+    "resourceReference" : "/system.services/Docker",
+    "timestamp" : "2022-01-25T18:34:11.199Z",
+    "type" : 63
+  }, {
+    "label" : "Docker.getDiskUsage",
+    "name" : "Docker.getDiskUsage",
+    "procedureName" : "getDiskUsage",
+    "resourceReference" : "/procedures/Docker.getDiskUsage",
+    "serviceName" : "Docker",
+    "timestamp" : "2022-01-25T20:44:24.963Z",
+    "type" : 3
+  }, {
+    "label" : "Docker.getStats",
+    "name" : "Docker.getStats",
+    "procedureName" : "getStats",
+    "resourceReference" : "/procedures/Docker.getStats",
+    "serviceName" : "Docker",
+    "timestamp" : "2022-01-25T19:19:45.025Z",
+    "type" : 3
+  }, {
+    "label" : "Docker.listContainers",
+    "name" : "Docker.listContainers",
+    "procedureName" : "listContainers",
+    "resourceReference" : "/procedures/Docker.listContainers",
+    "serviceName" : "Docker",
+    "timestamp" : "2022-01-25T21:11:01.775Z",
+    "type" : 3
+  }, {
+    "label" : "DockerAPI",
+    "name" : "DockerAPI",
+    "resourceReference" : "/sources/DockerAPI",
+    "timestamp" : "2022-01-25T18:37:38.288Z",
+    "type" : 4
+  }, {
+    "label" : "DockerMonitor",
+    "name" : "DockerMonitor",
+    "resourceReference" : "/system.clients/DockerMonitor",
+    "timestamp" : "2022-03-02T16:42:18.360Z",
+    "type" : 15
+  }, {
+    "name" : "internal_vantiq_com_br_cat",
+    "resourceReference" : "/system.catalogs/internal_vantiq_com_br_cat",
+    "timestamp" : "2022-02-02T19:30:03.234Z",
+    "type" : 67
+  }, {
+    "label" : "listContainers",
+    "name" : "listContainers",
+    "resourceReference" : "/types/listContainers",
+    "timestamp" : "2022-01-25T20:33:31.666Z",
+    "type" : 1
+  } ],
+  "tools" : [ {
+    "isPinned" : false,
+    "name" : "DockerMonitor",
+    "pane" : {
+      "c" : 1,
+      "r" : 0
+    },
+    "resourceKey" : "client/DockerMonitor",
+    "state" : 2,
+    "type" : 63
+  }, {
+    "isPinned" : false,
+    "name" : "Errors",
+    "type" : 13
+  }, {
+    "dockLocation" : "top",
+    "isPinned" : false,
+    "name" : "Inactive Panes",
+    "type" : 99
+  }, {
+    "isPinned" : false,
+    "name" : "Log Messages",
+    "type" : 12
+  }, {
+    "isPinned" : false,
+    "name" : "Project Contents",
+    "type" : 2
+  } ],
+  "type" : "dev",
+  "views" : [ {
+    "name" : "Project Contents",
+    "projectToolKeys" : [ "client/DockerMonitor", "errorviewer/Errors", "tiledock/Inactive Panes", "logviewer/Log Messages", "list/Project Contents" ]
+  } ]
+}

--- a/DockerMonitor/services/Docker.json
+++ b/DockerMonitor/services/Docker.json
@@ -1,0 +1,4 @@
+{
+  "ars_relationships" : [ ],
+  "name" : "Docker"
+}

--- a/DockerMonitor/sources/DockerAPI.json
+++ b/DockerMonitor/sources/DockerAPI.json
@@ -1,0 +1,20 @@
+{
+  "activationConstraint" : "",
+  "active" : true,
+  "ars_properties" : null,
+  "ars_relationships" : [ ],
+  "config" : {
+    "passwordType" : "string",
+    "pollingInterval" : 0,
+    "query" : { },
+    "requestDefaults" : {
+      "responseType" : "application/json"
+    },
+    "uri" : "http://host.docker.internal:2375/"
+  },
+  "direction" : "BOTH",
+  "messageType" : null,
+  "mockProcedures" : { },
+  "name" : "DockerAPI",
+  "type" : "REMOTE"
+}

--- a/DockerMonitor/types/listContainers.json
+++ b/DockerMonitor/types/listContainers.json
@@ -1,0 +1,65 @@
+{
+  "ars_properties" : null,
+  "ars_relationships" : [ ],
+  "groupBy" : "",
+  "name" : "listContainers",
+  "properties" : {
+    "DiskAvailable" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "String",
+      "unique" : false
+    },
+    "DiskSize" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "String",
+      "unique" : false
+    },
+    "DiskUsage" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "String",
+      "unique" : false
+    },
+    "DiskUsed" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "String",
+      "unique" : false
+    },
+    "containerId" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "String",
+      "unique" : false
+    },
+    "containerName" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "String",
+      "unique" : false
+    },
+    "cpuPercent" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "String",
+      "unique" : false
+    },
+    "memPercent" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "String",
+      "unique" : false
+    }
+  },
+  "role" : "schema"
+}


### PR DESCRIPTION
Simple Vantiq Client Builder application that can monitor docker containers resource utilization for the local host system. 

The utilization data is provided by the docker API.

Instructions on how to enable the Docker API and make it accessible to the containers is available here: 
https://github.com/pburma/vantiqexamples/tree/master/docker_examples/system_monitor

Once the docker API is active and accessible this project will load usage data from each container. 
![image](https://user-images.githubusercontent.com/11183903/156450749-089cd78a-2b88-4f7d-9ead-2db2c0e28246.png)

This information can be used to create custom alerts and monitor system health. For example to send a low disk space alert or high CPU utilization notification. 
