### PR TITLE
Update "processRequest" to match updated "executePlan"

### DIFF
--- a/TripPlanner/procedures/com/vantiq/trip/TripPlanner_processRequest.vail
+++ b/TripPlanner/procedures/com/vantiq/trip/TripPlanner_processRequest.vail
@@ -31,6 +31,5 @@ var plan = TripPlanner.planTripRequest(planInput, {})
 var trip = TripPlanner.ActiveCollabsGetById(config.collaborationId, "trip")
 var result = io.vantiq.ai.Agent.executePlan(plan, input, trip.id)
 
-// The result of the plan is an array of artifacts.  The first of these contains a "solution"
-// ready to be presented to the user. We return that.
-return result.head().getValue()
+// Return the generated response (which is intended to be "user friendly")
+return result.response


### PR DESCRIPTION
We normalized the return here, so we need to use the *response* property and not paw through artifacts.

Fixes #42