### PR TITLE
use isReadonly to prevent TripPlanner input until Service is initialized

### DIFF
--- a/TripPlanner/clients/com/vantiq/trip/TripPlanner/controllers/page/Start/onClientStart.js
+++ b/TripPlanner/clients/com/vantiq/trip/TripPlanner/controllers/page/Start/onClientStart.js
@@ -1,3 +1,6 @@
+    // lock the text-entry field in Conversation widget until TripPlanner service is initialized
+    client.getWidget("Conversation1").isReadOnly = true;
+
     var trip = {id: crypto.randomUUID()};
     var args = {
         entityId: trip.id,
@@ -6,4 +9,5 @@
     client.execute(args, "com.vantiq.trip.TripPlanner.tripActivate", function(collaborationId) {
         client.setCollaborationContext({id: collaborationId});
         client.data.tripId = trip.id;
+        client.getWidget("Conversation1").isReadOnly = false;  // unlock the text-entry field
     });

--- a/TripPlanner/clients/com/vantiq/trip/TripPlannerDiscussion/controllers/page/Start/onClientStart.js
+++ b/TripPlanner/clients/com/vantiq/trip/TripPlannerDiscussion/controllers/page/Start/onClientStart.js
@@ -1,3 +1,5 @@
+    // lock the text-entry field in Discussion widget until TripPlannerDiscussion service is initialized
+    client.getWidget("dwTripDiscussion").isReadOnly = true;
     
     // Configure the menu items for the tree nodes
 
@@ -45,6 +47,7 @@
             rootNode.addChild(newTreeNode);
         });
            
+        client.getWidget("dwTripDiscussion").isReadOnly = false;  // unlock the text-entry field
     });
 
 


### PR DESCRIPTION
Do this in both clients, i.e. for Conversation and Discussion variants

Fixes #48